### PR TITLE
Fix PDF footer and release metadata

### DIFF
--- a/.github/workflows/readme-qa.yml
+++ b/.github/workflows/readme-qa.yml
@@ -4,14 +4,28 @@ on:
   pull_request:
     paths:
       - README.md
+      - book/package-lock.json
+      - book/package.json
+      - book/qa.mjs
+      - book/readme-press.config.mjs
+      - book/release-metadata.mjs
+      - book/release-metadata.test.mjs
       - book/source-qa.mjs
+      - .github/workflows/release-book.yml
       - .github/workflows/readme-qa.yml
   push:
     branches:
       - main
     paths:
       - README.md
+      - book/package-lock.json
+      - book/package.json
+      - book/qa.mjs
+      - book/readme-press.config.mjs
+      - book/release-metadata.mjs
+      - book/release-metadata.test.mjs
       - book/source-qa.mjs
+      - .github/workflows/release-book.yml
       - .github/workflows/readme-qa.yml
   workflow_dispatch:
 
@@ -20,12 +34,26 @@ permissions:
 
 jobs:
   rtl-source:
-    name: Check GitHub RTL block direction
+    name: Check source and release metadata
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Check out the source
         uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: book/package-lock.json
+
+      - name: Test release metadata
+        run: |
+          npm ci --prefix book
+          npm test --prefix book
+          node --check book/qa.mjs
+          node --check book/readme-press.config.mjs
 
       - name: Reject prose whose first strong character is Latin
         run: node book/source-qa.mjs README.md

--- a/.github/workflows/release-book.yml
+++ b/.github/workflows/release-book.yml
@@ -64,8 +64,31 @@ jobs:
             echo "prerelease=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: book/package-lock.json
+
+      - name: Install and test book metadata
+        run: |
+          npm ci --prefix book
+          npm test --prefix book
+
+      - name: Capture the release date in Iran time
+        id: release-date
+        shell: bash
+        run: |
+          set -euo pipefail
+          release_date="$(TZ=Asia/Tehran date +%F)"
+          echo "date=$release_date" >> "$GITHUB_OUTPUT"
+          echo "Release date: $release_date (Asia/Tehran)"
+
       - name: Build and fully verify both PDF qualities
         uses: 3lf/readme-press@v0.1.1
+        env:
+          README_PRESS_RELEASE_DATE: ${{ steps.release-date.outputs.date }}
         with:
           command: pipeline
           config: book/readme-press.config.mjs

--- a/book/README.md
+++ b/book/README.md
@@ -33,9 +33,10 @@ brew install poppler qpdf
 ```bash
 git clone --branch v0.1.1 --depth 1 https://github.com/3lf/readme-press.git .readme-press
 npm ci --prefix .readme-press
+npm ci --prefix book
 ```
 
-هر وقت نسخه README Press در workflow عوض شد، شماره tag همین فرمان هم باید با اون هماهنگ بشه.
+فرمان آخر کتابخانه تبدیل دقیق تاریخ جلالی رو نصب می‌کنه. هر وقت نسخه README Press در workflow عوض شد، شماره tag همین فرمان هم باید با اون هماهنگ بشه.
 
 ## خروجی دلخواهت رو بساز 🏗️
 
@@ -86,12 +87,18 @@ node .readme-press/bin/readme-press.mjs qa \
 برای ساخت، بررسی کامل و آماده‌کردن فایل‌های انتشار با یک فرمان می‌تونی از پایپلاین استفاده کنی:
 
 ```bash
+release_version=v1.1.0
+release_date="$(TZ=Asia/Tehran date +%F)"
+README_PRESS_RELEASE_VERSION="$release_version" \
+README_PRESS_RELEASE_DATE="$release_date" \
 node .readme-press/bin/readme-press.mjs pipeline \
   --config book/readme-press.config.mjs \
-  --release-version v1.0.0 \
+  --release-version "$release_version" \
   --commit FULL_GIT_COMMIT \
   --render-all
 ```
+
+پایپلاین GitHub همین تاریخ رو یک بار با منطقه زمانی `Asia/Tehran` ثبت می‌کنه. بعد `jalaali-js` اون رو به تاریخ شمسی تبدیل می‌کنه و نسخه انتشار و هر دو تاریخ شمسی و میلادی رو روی جلد و صفحه شناسنامه می‌نویسه. اگه نسخه یا تاریخ ناقص یا نامعتبر باشه، ساخت PDF متوقف می‌شه.
 
 ## نسخه جدید رو منتشر کن 🚀
 
@@ -107,7 +114,7 @@ node .readme-press/bin/readme-press.mjs pipeline \
 
 ## حواست به فایل‌های محلی باشه 🧹
 
-پوشه `.readme-press/`، خروجی‌های `book/dist/`، فایل‌های PDF و کش‌های ساخت عمداً نباید وارد commit بشن. این مسیرها برای حفظ تاریخ قدیمی `.gitignore` به اون فایل اضافه نمی‌شن؛ پس قبل از هر commit حتماً وضعیت Git رو ببین و فقط فایل‌های لازم رو با اسم دقیق stage کن.
+پوشه `.readme-press/`، پوشه `book/node_modules/`، خروجی‌های `book/dist/`، فایل‌های PDF و کش‌های ساخت عمداً نباید وارد commit بشن. این مسیرها برای حفظ تاریخ قدیمی `.gitignore` به اون فایل اضافه نمی‌شن؛ پس قبل از هر commit حتماً وضعیت Git رو ببین و فقط فایل‌های لازم رو با اسم دقیق stage کن.
 
 ```bash
 git status --short

--- a/book/package-lock.json
+++ b/book/package-lock.json
@@ -1,0 +1,24 @@
+{
+  "name": "llm-for-humans-book-metadata",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "llm-for-humans-book-metadata",
+      "version": "1.0.0",
+      "dependencies": {
+        "jalaali-js": "2.0.0"
+      }
+    },
+    "node_modules/jalaali-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jalaali-js/-/jalaali-js-2.0.0.tgz",
+      "integrity": "sha512-HkWlwO3KxuYwERP1jsn+5M+QA+EKpIJ+zGesLee5VJNn2d2Melue0uQIvd9C/0QYFR7XVWvfF/uiNEz9Jbr9Hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    }
+  }
+}

--- a/book/package.json
+++ b/book/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "llm-for-humans-book-metadata",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test release-metadata.test.mjs"
+  },
+  "dependencies": {
+    "jalaali-js": "2.0.0"
+  }
+}

--- a/book/qa.mjs
+++ b/book/qa.mjs
@@ -14,6 +14,7 @@ export default async function runProjectQa({ config, manifest, check }) {
   const html = normalHtml ?? highHtml ?? '';
   const css = readFileSync(config.theme.stylesheet, 'utf8');
   const repositoryQr = readFileSync(resolve(config.outputDir, manifest.repositoryQr.asset), 'utf8');
+  const releaseMetadata = config.qa.releaseMetadata;
 
   check(manifest.parts.length === 9, 'project has nine configured parts', String(manifest.parts.length));
   check(manifest.chapters.length === 30, 'project has the expected chapter inventory', String(manifest.chapters.length));
@@ -42,8 +43,8 @@ export default async function runProjectQa({ config, manifest, check }) {
     check(
       output.repositoryFooter?.stampedPages === output.pageCount - 1
         && output.repositoryFooter?.artifact === true
-        && output.repositoryFooter?.text === 'github.com/3lf/llm-for-humans',
-      `${output.quality} repository footer covers every body page as an artifact`,
+        && output.repositoryFooter?.text === config.repository.url,
+      `${output.quality} repository footer uses the absolute URL on every body page`,
       `${output.repositoryFooter?.stampedPages ?? 0} pages`,
     );
     check(
@@ -58,6 +59,16 @@ export default async function runProjectQa({ config, manifest, check }) {
       'high-quality PDF preserves the larger lossless image set',
       `${manifest.outputs.high.bytes} > ${manifest.outputs.normal.bytes}`,
     );
+  }
+  check(manifest.metadata?.edition === config.metadata.edition, 'manifest records the configured edition');
+  check(manifest.metadata?.localDate === config.metadata.localDate, 'manifest records the configured Persian date');
+  check(manifest.metadata?.latinDate === config.metadata.latinDate, 'manifest records the configured Latin cover line');
+  if (releaseMetadata?.isRelease) {
+    const plainHtml = html.replace(/<[^>]+>/g, '');
+    check(manifest.releaseVersion === releaseMetadata.releaseVersion, 'manifest release version matches pipeline metadata');
+    check(plainHtml.includes(releaseMetadata.persianDate), 'colophon uses the pipeline Persian release date');
+    check(plainHtml.includes(releaseMetadata.gregorianDate), 'colophon uses the pipeline Gregorian release date');
+    check(plainHtml.includes(releaseMetadata.releaseVersion), 'colophon shows the pipeline release version');
   }
 
   const imageDirectory = resolve(config.projectRoot, '../images');

--- a/book/readme-press.config.mjs
+++ b/book/readme-press.config.mjs
@@ -1,3 +1,7 @@
+import { resolveBookMetadata } from './release-metadata.mjs';
+
+const bookMetadata = resolveBookMetadata();
+
 export default {
   source: '../README.md',
   outputDir: 'dist',
@@ -6,9 +10,9 @@ export default {
     title: 'LLM به زبان آدمیزاد',
     subtitle: 'راهنمای فارسیِ مدل‌های زبانی بزرگ',
     author: 'علی نجفی',
-    edition: 'ویرایش اول · ۲۳ تیر ۱۴۰۵ · 14 July 2026',
-    localDate: '۲۳ تیر ۱۴۰۵',
-    latinDate: '14 July 2026',
+    edition: bookMetadata.edition,
+    localDate: bookMetadata.localDate,
+    latinDate: bookMetadata.latinDate,
     language: 'fa',
     direction: 'rtl',
     numerals: 'persian',
@@ -19,6 +23,9 @@ export default {
   repository: {
     url: 'https://github.com/3lf/llm-for-humans',
     branch: 'main',
+  },
+  footer: {
+    text: 'https://github.com/3lf/llm-for-humans',
   },
   cover: {
     titlePrefix: 'LLM',
@@ -99,6 +106,7 @@ export default {
       'https://github.com/3lf/llm-for-humans/blob/main/CONTRIBUTING.md',
       'https://github.com/3lf/llm-for-humans/blob/main/LICENSE',
     ],
+    releaseMetadata: bookMetadata,
   },
   release: {
     copy: {

--- a/book/release-metadata.mjs
+++ b/book/release-metadata.mjs
@@ -1,0 +1,101 @@
+import { toJalaali } from 'jalaali-js';
+
+const PERSIAN_DIGITS = '۰۱۲۳۴۵۶۷۸۹';
+const PERSIAN_MONTHS = [
+  'فروردین',
+  'اردیبهشت',
+  'خرداد',
+  'تیر',
+  'مرداد',
+  'شهریور',
+  'مهر',
+  'آبان',
+  'آذر',
+  'دی',
+  'بهمن',
+  'اسفند',
+];
+const RELEASE_VERSION = /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+const RELEASE_DATE = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+export const DEFAULT_BOOK_METADATA = Object.freeze({
+  edition: 'ویرایش اول · ۲۳ تیر ۱۴۰۵ · 14 July 2026',
+  localDate: '۲۳ تیر ۱۴۰۵',
+  latinDate: '14 July 2026',
+  persianDate: '۲۳ تیر ۱۴۰۵',
+  gregorianDate: '14 July 2026',
+  releaseVersion: null,
+  releaseDate: null,
+  isRelease: false,
+});
+
+function toPersianDigits(value) {
+  return String(value).replace(/\d/g, (digit) => PERSIAN_DIGITS[Number(digit)]);
+}
+
+function argumentValue(argv, name) {
+  const inline = argv.find((argument) => argument.startsWith(`${name}=`));
+  if (inline) return inline.slice(name.length + 1);
+  const index = argv.indexOf(name);
+  return index >= 0 ? argv[index + 1] : undefined;
+}
+
+function parseGregorianDate(value) {
+  const match = RELEASE_DATE.exec(value ?? '');
+  if (!match) throw new Error(`Invalid README_PRESS_RELEASE_DATE: ${value ?? '(missing)'}. Use YYYY-MM-DD.`);
+  const [, yearText, monthText, dayText] = match;
+  const year = Number(yearText);
+  const month = Number(monthText);
+  const day = Number(dayText);
+  const date = new Date(Date.UTC(year, month - 1, day));
+  if (
+    date.getUTCFullYear() !== year
+    || date.getUTCMonth() !== month - 1
+    || date.getUTCDate() !== day
+  ) {
+    throw new Error(`Invalid README_PRESS_RELEASE_DATE: ${value}. Use a real Gregorian date.`);
+  }
+  return { year, month, day };
+}
+
+export function formatReleaseMetadata({ releaseVersion, releaseDate }) {
+  if (!RELEASE_VERSION.test(releaseVersion ?? '')) {
+    throw new Error(`Invalid README_PRESS_RELEASE_VERSION: ${releaseVersion ?? '(missing)'}. Use vMAJOR.MINOR.PATCH.`);
+  }
+  const { year, month, day } = parseGregorianDate(releaseDate);
+  const { jy, jm, jd } = toJalaali(year, month, day);
+  const persianDate = `${toPersianDigits(jd)} ${PERSIAN_MONTHS[jm - 1]} ${toPersianDigits(jy)}`;
+  const gregorianDate = `ISO ${releaseDate}`;
+
+  return {
+    edition: `ویرایش اول · ${persianDate} · ${gregorianDate}`,
+    localDate: persianDate,
+    latinDate: `${releaseVersion} · ${gregorianDate}`,
+    persianDate,
+    gregorianDate,
+    releaseVersion,
+    releaseDate,
+    isRelease: true,
+  };
+}
+
+export function resolveBookMetadata({ env = process.env, argv = process.argv } = {}) {
+  const environmentVersion = env.README_PRESS_RELEASE_VERSION?.trim();
+  const argumentVersion = argumentValue(argv, '--release-version')?.trim();
+  if (environmentVersion && argumentVersion && environmentVersion !== argumentVersion) {
+    throw new Error(
+      `Release version mismatch: README_PRESS_RELEASE_VERSION is ${environmentVersion}, but --release-version is ${argumentVersion}.`,
+    );
+  }
+
+  const releaseVersion = environmentVersion || argumentVersion;
+  const releaseDate = env.README_PRESS_RELEASE_DATE?.trim();
+  if (!releaseVersion && !releaseDate) return { ...DEFAULT_BOOK_METADATA };
+  if (!releaseVersion) {
+    throw new Error('README_PRESS_RELEASE_DATE requires README_PRESS_RELEASE_VERSION or --release-version.');
+  }
+  if (!releaseDate) {
+    throw new Error('README_PRESS_RELEASE_DATE is required for a release PDF build.');
+  }
+  return formatReleaseMetadata({ releaseVersion, releaseDate });
+}

--- a/book/release-metadata.test.mjs
+++ b/book/release-metadata.test.mjs
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  DEFAULT_BOOK_METADATA,
+  formatReleaseMetadata,
+  resolveBookMetadata,
+} from './release-metadata.mjs';
+
+test('formats the pipeline release date for the cover and colophon', () => {
+  const metadata = formatReleaseMetadata({
+    releaseVersion: 'v1.1.0-rc.1',
+    releaseDate: '2026-08-02',
+  });
+
+  assert.deepEqual(metadata, {
+    edition: 'ویرایش اول · ۱۱ مرداد ۱۴۰۵ · ISO 2026-08-02',
+    localDate: '۱۱ مرداد ۱۴۰۵',
+    latinDate: 'v1.1.0-rc.1 · ISO 2026-08-02',
+    persianDate: '۱۱ مرداد ۱۴۰۵',
+    gregorianDate: 'ISO 2026-08-02',
+    releaseVersion: 'v1.1.0-rc.1',
+    releaseDate: '2026-08-02',
+    isRelease: true,
+  });
+});
+
+test('converts Persian New Year boundaries with jalaali-js', () => {
+  assert.equal(formatReleaseMetadata({
+    releaseVersion: 'v1.0.0',
+    releaseDate: '2026-03-20',
+  }).persianDate, '۲۹ اسفند ۱۴۰۴');
+  assert.equal(formatReleaseMetadata({
+    releaseVersion: 'v1.0.0',
+    releaseDate: '2026-03-21',
+  }).persianDate, '۱ فروردین ۱۴۰۵');
+  assert.equal(formatReleaseMetadata({
+    releaseVersion: 'v1.0.0',
+    releaseDate: '2025-03-20',
+  }).persianDate, '۳۰ اسفند ۱۴۰۳');
+});
+
+test('keeps the committed edition metadata outside release builds', () => {
+  assert.deepEqual(resolveBookMetadata({ env: {}, argv: ['node', 'config.mjs'] }), {
+    ...DEFAULT_BOOK_METADATA,
+  });
+});
+
+test('accepts the CLI release version when it matches the pipeline date', () => {
+  const metadata = resolveBookMetadata({
+    env: { README_PRESS_RELEASE_DATE: '2026-08-02' },
+    argv: ['node', 'readme-press.mjs', 'pipeline', '--release-version', 'v1.1.0'],
+  });
+  assert.equal(metadata.releaseVersion, 'v1.1.0');
+});
+
+test('rejects incomplete or conflicting pipeline metadata', () => {
+  assert.throws(
+    () => resolveBookMetadata({
+      env: { README_PRESS_RELEASE_VERSION: 'v1.1.0' },
+      argv: ['node', 'config.mjs'],
+    }),
+    /README_PRESS_RELEASE_DATE is required/,
+  );
+  assert.throws(
+    () => resolveBookMetadata({
+      env: { README_PRESS_RELEASE_DATE: '2026-08-02' },
+      argv: ['node', 'config.mjs'],
+    }),
+    /requires README_PRESS_RELEASE_VERSION/,
+  );
+  assert.throws(
+    () => resolveBookMetadata({
+      env: {
+        README_PRESS_RELEASE_VERSION: 'v1.1.0',
+        README_PRESS_RELEASE_DATE: '2026-08-02',
+      },
+      argv: ['node', 'readme-press.mjs', 'pipeline', '--release-version', 'v2.0.0'],
+    }),
+    /Release version mismatch/,
+  );
+});
+
+test('rejects invalid versions and impossible Gregorian dates', () => {
+  assert.throws(
+    () => formatReleaseMetadata({ releaseVersion: '1.1.0', releaseDate: '2026-08-02' }),
+    /Invalid README_PRESS_RELEASE_VERSION/,
+  );
+  assert.throws(
+    () => formatReleaseMetadata({ releaseVersion: 'v1.1.0', releaseDate: '2026-02-29' }),
+    /real Gregorian date/,
+  );
+});

--- a/docs/plans/2026-08-02-pdf-release-metadata-design.md
+++ b/docs/plans/2026-08-02-pdf-release-metadata-design.md
@@ -1,0 +1,38 @@
+# PDF release metadata design
+
+## Goal
+
+Make every release PDF show trustworthy release metadata without manual edits:
+
+- an absolute repository URL in the footer
+- the release version on the cover
+- one pipeline-generated release date on both the cover and colophon
+- a correctly converted Persian calendar date based on `Asia/Tehran`
+
+## Selected approach
+
+Keep the implementation in this repository so the fix can ship in one pull request without waiting for a separate README Press release.
+
+The release workflow records one Gregorian date in `Asia/Tehran` at the start of the build. It passes that value to the book configuration. A small metadata helper validates the input, converts it with `jalaali-js`, and returns the exact strings used by the cover and colophon. Both PDF quality variants therefore receive identical metadata.
+
+Local non-release builds keep the existing edition metadata so contributors can build without release-only environment variables. A pipeline build fails when its release date or version is absent or invalid.
+
+## Output contract
+
+The cover shows:
+
+- the Persian release date
+- the release version and Gregorian release date
+
+The colophon shows:
+
+- the edition with the same Persian and Gregorian dates
+- the existing dedicated release-version row
+
+Every body-page footer displays the complete `https://github.com/3lf/llm-for-humans` URL so PDF viewers cannot interpret it as a local relative path.
+
+## Validation
+
+Unit tests cover known Persian New Year boundaries, Persian-digit formatting, release-version validation, invalid dates, and non-release fallbacks. Project QA verifies that release builds carry the expected cover and colophon strings and that the stamped footer equals the canonical absolute repository URL.
+
+The final release-like PDF is checked through its manifest, extracted text, link annotations, and rendered cover, colophon, and body footer pages.


### PR DESCRIPTION
## What changed

- stamps the canonical `https://github.com/3lf/llm-for-humans` URL in every body-page footer
- captures one release date in `Asia/Tehran` during the release workflow
- converts that date with `jalaali-js` and writes the Persian date, ISO date, and release version to the cover and colophon
- rejects missing, conflicting, or invalid release metadata
- adds focused metadata tests and makes the lightweight PR workflow run them
- documents the local release build contract

## Root cause

README Press stamped the display form `github.com/3lf/llm-for-humans` as footer text without a link annotation. PDF viewers could auto-detect it as a relative path and open a local `file:///.../github.com/3lf/llm-for-humans` URL.

The book dates were also committed as static configuration, so a later release could retain an older cover and colophon date. The release version was present in the colophon but not on the cover.

## Impact

Released PDFs now expose an absolute footer URL and carry metadata from the actual pipeline run. Both quality variants use the same Tehran release date. The cover and colophon show the Persian date, an unambiguous ISO date, and the selected release version.

## Validation

- `npm test --prefix book`: 6 tests passed, including Persian New Year boundaries
- `node book/source-qa.mjs README.md`: passed
- `actionlint` for all workflow files: passed
- README Press `v0.1.1` release-like pipeline: both 265-page variants passed full QA
- all 530 PDF pages rendered successfully with Poppler
- all 50 high-quality figures matched their source PNG pixels
- footer, cover, and colophon were visually inspected after the final bidi-safe date adjustment
- PDF URI inspection found no local or relative GitHub URI annotations

## Note

The commits are unsigned because GPG signing is unavailable in this shell. The owner can re-sign them when merging.
