### PR TITLE
Protect README source parsing and internal anchors

### DIFF
--- a/book/package.json
+++ b/book/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "node --test release-metadata.test.mjs"
+    "test": "node --test"
   },
   "dependencies": {
     "jalaali-js": "2.0.0"

--- a/book/source-qa.mjs
+++ b/book/source-qa.mjs
@@ -50,14 +50,33 @@ function isFenceCloser(line, fence) {
   );
 }
 
+function isIndentedCodeLine(line) {
+  const { body } = splitBlockQuotePrefix(line);
+  let columns = 0;
+  for (const character of body) {
+    if (character === ' ') {
+      columns += 1;
+    } else if (character === '\t') {
+      columns += 4 - (columns % 4);
+    } else {
+      break;
+    }
+    if (columns >= 4) return true;
+  }
+  return false;
+}
+
 function sourceLines(source) {
   const result = [];
   let fence = null;
+  let indentedCode = false;
+  let previousLineWasBlank = true;
 
   for (const [index, line] of source.split(/\r?\n/u).entries()) {
     if (fence) {
       if (isFenceCloser(line, fence)) {
         fence = null;
+        previousLineWasBlank = true;
         result.push({ closingFence: true, inFence: true, line, lineNumber: index + 1 });
       } else {
         result.push({ closingFence: false, inFence: true, line, lineNumber: index + 1 });
@@ -65,14 +84,33 @@ function sourceLines(source) {
       continue;
     }
 
+    let startsAfterCode = false;
+    if (indentedCode) {
+      if (!line.trim() || isIndentedCodeLine(line)) {
+        result.push({ closingFence: false, inFence: true, line, lineNumber: index + 1 });
+        continue;
+      }
+      indentedCode = false;
+      startsAfterCode = true;
+    }
+
     const opener = parseFenceOpener(line);
     if (opener) {
       fence = opener;
+      previousLineWasBlank = false;
       result.push({ closingFence: false, inFence: true, line, lineNumber: index + 1 });
       continue;
     }
 
-    result.push({ closingFence: false, inFence: false, line, lineNumber: index + 1 });
+    if (previousLineWasBlank && line.trim() && isIndentedCodeLine(line)) {
+      indentedCode = true;
+      previousLineWasBlank = false;
+      result.push({ closingFence: false, inFence: true, line, lineNumber: index + 1 });
+      continue;
+    }
+
+    result.push({ closingFence: false, inFence: false, line, lineNumber: index + 1, startsAfterCode });
+    previousLineWasBlank = !line.trim();
   }
 
   return result;
@@ -87,6 +125,8 @@ export function findUnsafeGitHubBlockStarts(source) {
       if (entry.closingFence) previousWasBlank = true;
       continue;
     }
+
+    if (entry.startsAfterCode) previousWasBlank = true;
 
     const trimmed = entry.line.trim();
     if (!trimmed) {

--- a/book/source-qa.mjs
+++ b/book/source-qa.mjs
@@ -2,52 +2,242 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
-export function findUnsafeGitHubBlockStarts(source) {
-  const ltr = [];
-  let inFence = false;
-  let previousWasBlank = true;
+const STRONG_CHARACTER = /[\p{Script=Arabic}\p{Script=Latin}]/u;
+const LATIN_CHARACTER = /\p{Script=Latin}/u;
+const SLUG_CHARACTER = /[\p{Alphabetic}\p{Mark}\p{Number}]/u;
+
+function splitBlockQuotePrefix(line) {
+  let cursor = 0;
+  let depth = 0;
+
+  while (true) {
+    const markerStart = cursor;
+    let indentation = 0;
+    while (indentation < 3 && line[cursor] === ' ') {
+      cursor += 1;
+      indentation += 1;
+    }
+    if (line[cursor] !== '>') {
+      cursor = markerStart;
+      break;
+    }
+    cursor += 1;
+    if (line[cursor] === ' ') cursor += 1;
+    depth += 1;
+  }
+
+  return { body: line.slice(cursor), depth };
+}
+
+function parseFenceOpener(line) {
+  const quote = splitBlockQuotePrefix(line);
+  const match = quote.body.match(/^ {0,3}(`{3,}|~{3,})(.*)$/u);
+  if (!match) return null;
+
+  const marker = match[1];
+  if (marker[0] === '`' && match[2].includes('`')) return null;
+  return { character: marker[0], depth: quote.depth, length: marker.length };
+}
+
+function isFenceCloser(line, fence) {
+  const quote = splitBlockQuotePrefix(line);
+  if (quote.depth !== fence.depth) return false;
+  const match = quote.body.match(/^ {0,3}(`+|~+)[ \t]*$/u);
+  return Boolean(
+    match
+    && match[1][0] === fence.character
+    && match[1].length >= fence.length,
+  );
+}
+
+function sourceLines(source) {
+  const result = [];
+  let fence = null;
 
   for (const [index, line] of source.split(/\r?\n/u).entries()) {
-    const lineNumber = index + 1;
-    const trimmed = line.trim();
-    const fenceProbe = trimmed.replace(/^>\s?/u, '');
-
-    if (fenceProbe.startsWith('```')) {
-      inFence = !inFence;
-      previousWasBlank = false;
+    if (fence) {
+      if (isFenceCloser(line, fence)) {
+        fence = null;
+        result.push({ closingFence: true, inFence: true, line, lineNumber: index + 1 });
+      } else {
+        result.push({ closingFence: false, inFence: true, line, lineNumber: index + 1 });
+      }
       continue;
     }
-    if (inFence) continue;
+
+    const opener = parseFenceOpener(line);
+    if (opener) {
+      fence = opener;
+      result.push({ closingFence: false, inFence: true, line, lineNumber: index + 1 });
+      continue;
+    }
+
+    result.push({ closingFence: false, inFence: false, line, lineNumber: index + 1 });
+  }
+
+  return result;
+}
+
+export function findUnsafeGitHubBlockStarts(source) {
+  const ltr = [];
+  let previousWasBlank = true;
+
+  for (const entry of sourceLines(source)) {
+    if (entry.inFence) {
+      if (entry.closingFence) previousWasBlank = true;
+      continue;
+    }
+
+    const trimmed = entry.line.trim();
     if (!trimmed) {
       previousWasBlank = true;
       continue;
     }
 
-    const quoteBlock = line.match(/^\s*>\s?(.*)$/u);
-    const blockBody = quoteBlock?.[1] ?? line;
-    const markedBlock = blockBody.match(
+    const quote = splitBlockQuotePrefix(entry.line);
+    const markedBlock = quote.body.match(
       /^\s*(?:(?:[-*+]\s+)|(?:[0-9۰-۹]+\.\s+)|(?:#{1,6}\s+))(.+)$/u,
     );
-    let content = markedBlock?.[1]?.trim() ?? quoteBlock?.[1]?.trim() ?? null;
+    let content = markedBlock?.[1]?.trim() ?? (quote.depth > 0 ? quote.body.trim() : null);
+    const blockProbe = quote.body.trim();
     if (
       !content
       && previousWasBlank
-      && !/^(?:<|!\[|\||-{3,}$|\[[^\]]+\]:)/u.test(trimmed)
+      && !/^(?:<|!\[|\||-{3,}$|\[[^\]]+\]:)/u.test(blockProbe)
     ) {
       content = trimmed;
     }
 
     if (content) {
       const visibleStart = content.replace(/^[*_~`]+/u, '');
-      const firstStrong = [...visibleStart].find((character) => (
-        /[\p{Script=Arabic}\p{Script=Latin}]/u.test(character)
-      ));
-      if (firstStrong && /\p{Script=Latin}/u.test(firstStrong)) ltr.push(lineNumber);
+      const firstStrong = [...visibleStart].find((character) => STRONG_CHARACTER.test(character));
+      if (firstStrong && LATIN_CHARACTER.test(firstStrong)) ltr.push(entry.lineNumber);
     }
     previousWasBlank = false;
   }
 
   return { ltr };
+}
+
+function decodeHtmlEntities(value) {
+  const named = new Map([
+    ['amp', '&'],
+    ['apos', "'"],
+    ['gt', '>'],
+    ['lt', '<'],
+    ['nbsp', ' '],
+    ['quot', '"'],
+    ['zwnj', '\u200c'],
+    ['zwj', '\u200d'],
+  ]);
+  return value.replace(/&(#(?:x[0-9a-f]+|[0-9]+)|[a-z]+);/giu, (entity, key) => {
+    if (key[0] !== '#') return named.get(key.toLowerCase()) ?? entity;
+    const hexadecimal = key[1]?.toLowerCase() === 'x';
+    const codePoint = Number.parseInt(key.slice(hexadecimal ? 2 : 1), hexadecimal ? 16 : 10);
+    try {
+      return String.fromCodePoint(codePoint);
+    } catch {
+      return entity;
+    }
+  });
+}
+
+function replaceInlineCode(value) {
+  return value.replace(/(`+)(.*?)\1/gu, (_match, _marker, content) => {
+    const collapsed = content.replace(/[ \t]+/gu, ' ');
+    if (/^ .* $/u.test(collapsed) && !/^ +$/u.test(collapsed)) return collapsed.slice(1, -1);
+    return collapsed;
+  });
+}
+
+export function visibleHeadingText(markdown) {
+  let value = markdown;
+  value = replaceInlineCode(value);
+  value = value.replace(/!?\[([^\]\r\n]*)\]\([^)]*\)/gu, '$1');
+  value = value.replace(/!?\[([^\]\r\n]*)\]\[[^\]\r\n]*\]/gu, '$1');
+  value = value.replace(/<[^>]+>/gu, '');
+  for (const delimiter of ['**', '__', '~~', '*', '_']) {
+    const escaped = delimiter.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&');
+    value = value.replace(new RegExp(`${escaped}(.+?)${escaped}`, 'gu'), '$1');
+  }
+  return decodeHtmlEntities(value);
+}
+
+export function githubHeadingSlug(markdown) {
+  const visible = visibleHeadingText(markdown).toLowerCase();
+  const retained = [...visible].filter((character) => (
+    character === ' '
+    || character === '-'
+    || character === '_'
+    || character === '\u200c'
+    || character === '\u200d'
+    || SLUG_CHARACTER.test(character)
+  ));
+  return retained.join('').replace(/ /gu, '-');
+}
+
+function extractHeading(line) {
+  const match = line.match(/^ {0,3}(#{1,6})(?:[ \t]+(.+?)|[ \t]*)$/u);
+  if (!match || !match[2]) return null;
+  const markdown = match[2].replace(/[ \t]+#+[ \t]*$/u, '').trimEnd();
+  return { markdown, text: visibleHeadingText(markdown) };
+}
+
+function maskInlineCode(line) {
+  return line.replace(/(`+)(.*?)\1/gu, (match) => ' '.repeat(match.length));
+}
+
+function decodeFragment(fragment) {
+  try {
+    return decodeURIComponent(fragment);
+  } catch {
+    return fragment;
+  }
+}
+
+export function validateInternalAnchors(source) {
+  const headings = [];
+  const links = [];
+  const occupied = new Set();
+  const nextSuffix = new Map();
+  let nearestHeading = null;
+
+  for (const entry of sourceLines(source)) {
+    if (entry.inFence) continue;
+
+    const heading = extractHeading(entry.line);
+    if (heading) {
+      const base = githubHeadingSlug(heading.markdown);
+      let slug = base;
+      let suffix = nextSuffix.get(base) ?? 0;
+      while (occupied.has(slug)) {
+        suffix += 1;
+        slug = `${base}-${suffix}`;
+      }
+      nextSuffix.set(base, suffix);
+      occupied.add(slug);
+      nearestHeading = heading.text;
+      headings.push({ line: entry.lineNumber, slug, text: heading.text });
+    }
+
+    const linkSource = maskInlineCode(entry.line);
+    const linkPattern = /\[[^\]\r\n]*\]\(\s*(#[^\s)]+)(?:\s+[^)]*)?\)/gu;
+    for (const match of linkSource.matchAll(linkPattern)) {
+      const fragment = match[1];
+      links.push({
+        fragment,
+        line: entry.lineNumber,
+        nearestHeading: nearestHeading ?? '(document start)',
+        target: decodeFragment(fragment.slice(1)),
+      });
+    }
+  }
+
+  const mismatches = links
+    .filter((link) => !occupied.has(link.target))
+    .map(({ fragment, line, nearestHeading }) => ({ fragment, line, nearestHeading }));
+
+  return { headings, links, mismatches };
 }
 
 function formatLines(lines) {
@@ -58,14 +248,30 @@ function runCli() {
   const sourcePath = resolve(process.argv[2] ?? 'README.md');
   const source = readFileSync(sourcePath, 'utf8');
   const unsafe = findUnsafeGitHubBlockStarts(source);
+  const anchors = validateInternalAnchors(source);
+  let failed = false;
 
   if (unsafe.ltr.length > 0) {
     console.error(`Latin-directed prose blocks: ${formatLines(unsafe.ltr)}`);
+    failed = true;
+  }
+  if (anchors.mismatches.length > 0) {
+    console.error('Internal anchor mismatches:');
+    for (const mismatch of anchors.mismatches) {
+      console.error(
+        `line ${mismatch.line}: fragment "${mismatch.fragment}" (nearest heading: "${mismatch.nearestHeading}")`,
+      );
+    }
+    failed = true;
+  }
+  if (failed) {
     process.exitCode = 1;
     return;
   }
 
-  console.log('README RTL source QA passed: no prose block starts with Latin text.');
+  console.log(
+    `README source QA passed: RTL block starts, ${anchors.headings.length} headings, and ${anchors.links.length} internal links.`,
+  );
 }
 
 const invokedModule = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : null;

--- a/book/source-qa.test.mjs
+++ b/book/source-qa.test.mjs
@@ -1,0 +1,190 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+
+import {
+  findUnsafeGitHubBlockStarts,
+  githubHeadingSlug,
+  validateInternalAnchors,
+  visibleHeadingText,
+} from './source-qa.mjs';
+
+const rtlCases = [
+  {
+    name: 'checks prose immediately after a closing fence',
+    source: '```js\nEnglish in code\n```\nEnglish prose',
+    expected: [4],
+  },
+  {
+    name: 'ignores inner triple backticks inside a quadruple fence',
+    source: '````\nEnglish\n```\nEnglish again\n````\nEnglish prose',
+    expected: [6],
+  },
+  {
+    name: 'supports tilde fences',
+    source: '~~~text\nEnglish\n~~~\nمتن فارسی',
+    expected: [],
+  },
+  {
+    name: 'requires a quoted fence closer at the opener depth',
+    source: '> ~~~~\n> English\n~~~~\n> English again\n> ~~~~\nEnglish prose',
+    expected: [6],
+  },
+  {
+    name: 'supports CRLF input',
+    source: '```\r\nEnglish\r\n```\r\nEnglish prose',
+    expected: [4],
+  },
+  {
+    name: 'checks bullets and ASCII-numbered lists',
+    source: '- English\n1. English',
+    expected: [1, 2],
+  },
+  {
+    name: 'checks Persian-numbered lists',
+    source: '۱۲. English',
+    expected: [1],
+  },
+  {
+    name: 'checks headings',
+    source: '## English heading',
+    expected: [1],
+  },
+  {
+    name: 'looks through emphasis markers',
+    source: '**English prose**',
+    expected: [1],
+  },
+  {
+    name: 'looks through neutral leading characters',
+    source: '✅ English prose',
+    expected: [1],
+  },
+  {
+    name: 'keeps structural exemptions',
+    source: '<div lang="en">\n\n![English](image.png)\n\n| English |\n\n---\n\n[ref]: https://example.com',
+    expected: [],
+  },
+];
+
+for (const fixture of rtlCases) {
+  test(fixture.name, () => {
+    assert.deepEqual(findUnsafeGitHubBlockStarts(fixture.source), { ltr: fixture.expected });
+  });
+}
+
+test('turns rendered inline Markdown into heading text', () => {
+  assert.equal(
+    visibleHeadingText('**Hello** `World` [Label](https://example.com) &amp; _more_'),
+    'Hello World Label & more',
+  );
+});
+
+test('matches GitHub Unicode slug behavior for joiners, selectors, and emoji fixtures', () => {
+  const fixtures = [
+    ['الف\u200cب', 'الف\u200cب'],
+    ['الف\u200dب', 'الف\u200dب'],
+    ['A\ufe0f', 'a\ufe0f'],
+    ['❤️‍🩹', '\ufe0f\u200d'],
+    ['🕵️‍♂️', '\ufe0f\u200d\ufe0f'],
+    ['👶👨‍🎓🕵️', '\u200d\ufe0f'],
+    ['🅰️/🅱️', '🅰️🅱️'],
+  ];
+  for (const [heading, expected] of fixtures) {
+    assert.equal(githubHeadingSlug(heading), expected, heading);
+  }
+});
+
+test('retains labels instead of URLs and strips inline formatting from headings', () => {
+  const result = validateInternalAnchors([
+    '# **Hello** `World` [Label](https://example.com)',
+    '[jump](#hello-world-label)',
+  ].join('\n'));
+  assert.equal(result.headings[0].slug, 'hello-world-label');
+  assert.deepEqual(result.mismatches, []);
+});
+
+test('suffixes duplicate headings and avoids collisions with existing suffixed headings', () => {
+  const result = validateInternalAnchors([
+    '# Alpha',
+    '# Alpha',
+    '# Alpha-1',
+    '# Alpha',
+    '[first](#alpha)',
+    '[second](#alpha-1)',
+    '[collision](#alpha-1-1)',
+    '[third](#alpha-2)',
+  ].join('\n'));
+  assert.deepEqual(result.headings.map(({ slug }) => slug), [
+    'alpha',
+    'alpha-1',
+    'alpha-1-1',
+    'alpha-2',
+  ]);
+  assert.deepEqual(result.mismatches, []);
+});
+
+test('ignores headings and links inside fences', () => {
+  const result = validateInternalAnchors([
+    '# Visible',
+    '```md',
+    '# Hidden',
+    '[bad](#missing)',
+    '```',
+    '[good](#visible)',
+  ].join('\n'));
+  assert.equal(result.headings.length, 1);
+  assert.equal(result.links.length, 1);
+  assert.deepEqual(result.mismatches, []);
+});
+
+test('reports every mismatch with its source line, fragment, and nearest heading', () => {
+  const result = validateInternalAnchors([
+    '# بخش اول',
+    '[خراب](#missing-one)',
+    '# بخش دوم',
+    '[خراب](#missing-two)',
+  ].join('\n'));
+  assert.deepEqual(result.mismatches, [
+    { line: 2, fragment: '#missing-one', nearestHeading: 'بخش اول' },
+    { line: 4, fragment: '#missing-two', nearestHeading: 'بخش دوم' },
+  ]);
+});
+
+test('CLI prints actionable anchor failures and exits nonzero', () => {
+  const directory = mkdtempSync(join(tmpdir(), 'source-qa-'));
+  const sourcePath = join(directory, 'README.md');
+  try {
+    writeFileSync(sourcePath, '# بخش\n[خراب](#missing)\n', 'utf8');
+    const result = spawnSync(process.execPath, [join(import.meta.dirname, 'source-qa.mjs'), sourcePath], {
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /Internal anchor mismatches:/u);
+    assert.match(result.stderr, /line 2: fragment "#missing"/u);
+    assert.match(result.stderr, /nearest heading: "بخش"/u);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test('current README keeps the rendered heading and internal-link baseline', () => {
+  const source = readFileSync(join(import.meta.dirname, '..', 'README.md'), 'utf8');
+  const result = validateInternalAnchors(source);
+  assert.equal(result.headings.length, 356);
+  assert.equal(result.links.length, 178);
+  assert.deepEqual(result.mismatches, []);
+});
+
+test('a deliberately altered current README fragment fails validation', () => {
+  const source = readFileSync(join(import.meta.dirname, '..', 'README.md'), 'utf8');
+  const altered = source.replace('](#مقدمه-)', '](#deliberately-missing)');
+  assert.notEqual(altered, source);
+  const result = validateInternalAnchors(altered);
+  assert.deepEqual(result.mismatches, [
+    { line: 82, fragment: '#deliberately-missing', nearestHeading: 'فهرست مطالب ✨' },
+  ]);
+});

--- a/book/source-qa.test.mjs
+++ b/book/source-qa.test.mjs
@@ -24,8 +24,23 @@ const rtlCases = [
     expected: [6],
   },
   {
+    name: 'accepts a longer matching fence closer',
+    source: '```\nEnglish\n`````  \nEnglish prose',
+    expected: [4],
+  },
+  {
+    name: 'rejects a backtick fence opener whose info string contains a backtick',
+    source: '```bad`info\nEnglish continuation',
+    expected: [1],
+  },
+  {
     name: 'supports tilde fences',
     source: '~~~text\nEnglish\n~~~\nمتن فارسی',
+    expected: [],
+  },
+  {
+    name: 'allows backticks in a tilde fence info string',
+    source: '~~~ bad`info\nEnglish\n~~~\nمتن فارسی',
     expected: [],
   },
   {
@@ -37,6 +52,16 @@ const rtlCases = [
     name: 'supports CRLF input',
     source: '```\r\nEnglish\r\n```\r\nEnglish prose',
     expected: [4],
+  },
+  {
+    name: 'treats tab-indented fence markers as indented code and checks following prose',
+    source: '\t```js\n\tEnglish\n\t```\nEnglish prose',
+    expected: [4],
+  },
+  {
+    name: 'treats four-space-indented blocks as code and checks following prose',
+    source: '    English code\n    more code\nEnglish prose',
+    expected: [3],
   },
   {
     name: 'checks bullets and ASCII-numbered lists',
@@ -141,6 +166,18 @@ test('ignores headings and links inside fences', () => {
   assert.deepEqual(result.mismatches, []);
 });
 
+test('ignores headings and links inside indented code blocks', () => {
+  const result = validateInternalAnchors([
+    '    # Hidden',
+    '    [bad](#missing)',
+    '# Visible',
+    '[good](#visible)',
+  ].join('\n'));
+  assert.equal(result.headings.length, 1);
+  assert.equal(result.links.length, 1);
+  assert.deepEqual(result.mismatches, []);
+});
+
 test('reports every mismatch with its source line, fragment, and nearest heading', () => {
   const result = validateInternalAnchors([
     '# بخش اول',
@@ -183,8 +220,11 @@ test('a deliberately altered current README fragment fails validation', () => {
   const source = readFileSync(join(import.meta.dirname, '..', 'README.md'), 'utf8');
   const altered = source.replace('](#مقدمه-)', '](#deliberately-missing)');
   assert.notEqual(altered, source);
+  const alteredLine = altered.split(/\r?\n/u)
+    .findIndex((line) => line.includes('](#deliberately-missing)')) + 1;
+  assert.ok(alteredLine > 0);
   const result = validateInternalAnchors(altered);
   assert.deepEqual(result.mismatches, [
-    { line: 82, fragment: '#deliberately-missing', nearestHeading: 'فهرست مطالب ✨' },
+    { line: alteredLine, fragment: '#deliberately-missing', nearestHeading: 'فهرست مطالب ✨' },
   ]);
 });


### PR DESCRIPTION
## Summary

- replace the fence toggle with character, length, blockquote-depth, and indented-code-aware parsing
- validate internal README fragments against rendered GitHub-style heading slugs
- preserve the public `findUnsafeGitHubBlockStarts` result shape used by book QA
- discover all Node test files automatically
- add parser, indented-code, Unicode, duplicate-heading, CLI, and live-baseline coverage
- derive the deliberately altered-link line from its fixture so unrelated README insertions cannot break the test
- keep the working A/B table-of-contents anchor unchanged

## Acceptance evidence

- 356 rendered headings discovered
- all 178 current internal links resolve
- a deliberately altered fragment fails with its line, fragment, and nearest heading
- 32 Node tests pass
- `node book/source-qa.mjs README.md` passes
- JavaScript syntax checks, actionlint, and `git diff --check` pass
- GitHub's complete three-edition PDF job is green
